### PR TITLE
No usages for importKey(ECDH)

### DIFF
--- a/index.html
+++ b/index.html
@@ -818,7 +818,7 @@ function preflight(){
                         key,
                         {name:"ECDH", namedCurve:"P-256"},
                         true,
-                        ['deriveBits'])
+                        [])
                         .then( key => {
                             /* And finally, can we derive bits from the
                              * imported key and the private key? This is

--- a/webpush.js
+++ b/webpush.js
@@ -110,7 +110,7 @@
                                sub.receiverKey,
                                P256DH,
                                true,
-                               ['deriveBits'])
+                               [])
       .then(receiverKey => {
           // Ok, we've got a representation of the remote key.
           // Now, derive a shared key from our temporary local key


### PR DESCRIPTION
Matching the Gecko patch in https://phabricator.services.mozilla.com/D222647. Closes #29

I confirmed that deriveBits call works without this.